### PR TITLE
ci: let components package build with ng-packagr

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,13 +49,20 @@ jobs:
           key: sparkles-{{ .Branch }}	-{{ checksum "yarn.lock" }}
           paths:
           - ~/app/node_modules
-      - run: ./scripts/ci.frontend.sh
+      - run:
+          command: ./scripts/ci/frontend.build.sh
+          name: Build
+      - run:
+          command: ./scripts/ci/frontend.test.sh
+          name: Test
       - store_artifacts:
           path: ~/app/dist
       - store_artifacts:
           path: ~/app/packages/components/dist
       - store_artifacts:
           path: ~/app/packages/styles/dist
+      - store_test_results:
+          path: ~/app/coverage
 
 workflows:
   version: 2

--- a/angular.json
+++ b/angular.json
@@ -208,6 +208,13 @@
       "projectType": "library",
       "prefix": "sparkles",
       "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-ng-packagr:build",
+          "options": {
+            "tsConfig": "packages/components/tsconfig.lib.json",
+            "project": "packages/components/package.json"
+          }
+        },
         "lint": {
           "builder": "@angular-devkit/build-angular:tslint",
           "options": {

--- a/package.json
+++ b/package.json
@@ -55,11 +55,13 @@
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "~0.13.1",
+    "@angular-devkit/build-ng-packagr": "~0.13.0",
     "@angular/cli": "7.3.4",
     "@angular/compiler-cli": "7.2.7",
     "@angular/language-service": "7.2.7",
     "@babel/register": "^7.0.0",
     "@ngrx/schematics": "7.3.0",
+    "@ngrx/store-devtools": "7.3.0",
     "@nrwl/builders": "7.6.2",
     "@nrwl/schematics": "7.6.2",
     "@types/jasmine": "~3.3.0",
@@ -71,6 +73,7 @@
     "babel-preset-es2015": "^6.24.1",
     "codelyzer": "~4.5.0",
     "cypress": "^3.1.0",
+    "dotenv": "6.2.0",
     "gulp": "^4.0.0",
     "gulp-postcss": "^8.0.0",
     "gulp-sass": "^4.0.2",
@@ -93,8 +96,6 @@
     "tsickle": "^0.34.0",
     "tslib": "^1.9.3",
     "tslint": "~5.13.0",
-    "typescript": "~3.2.2",
-    "dotenv": "6.2.0",
-    "@ngrx/store-devtools": "7.3.0"
+    "typescript": "~3.2.2"
   }
 }

--- a/scripts/ci/.affectedrc
+++ b/scripts/ci/.affectedrc
@@ -1,6 +1,3 @@
-#!/bin/bash
-set -e
-
 ###
 # On master, build all. On branches and pull requests, only build affected by change.
 # https://blog.nrwl.io/nrwl-nx-6-1-better-dev-ergonomics-faster-builds-3198bb310e39
@@ -9,8 +6,3 @@ if [ "${CIRCLE_BRANCH}" = "master" ] || [ -n "${CIRCLE_TAG}" ]; then
 else
   AFFECTED_ARGS="--base=origin/master --head=HEAD"
 fi
-
-yarn packages:styles:build
-yarn packages:components:build
-yarn affected:build ${AFFECTED_ARGS}
-xvfb-run -a yarn affected:test ${AFFECTED_ARGS}

--- a/scripts/ci/frontend.build.sh
+++ b/scripts/ci/frontend.build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+source scripts/ci/.affectedrc
+
+yarn packages:styles:build
+yarn affected:build ${AFFECTED_ARGS}

--- a/scripts/ci/frontend.test.sh
+++ b/scripts/ci/frontend.test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+source scripts/ci/.affectedrc
+
+xvfb-run -a yarn affected:test ${AFFECTED_ARGS}

--- a/yarn.lock
+++ b/yarn.lock
@@ -70,6 +70,16 @@
   optionalDependencies:
     node-sass "4.11.0"
 
+"@angular-devkit/build-ng-packagr@~0.13.0":
+  version "0.13.4"
+  resolved "https://registry.yarnpkg.com/@angular-devkit/build-ng-packagr/-/build-ng-packagr-0.13.4.tgz#149ea558fc7a093865113db078a653d2bcdd762c"
+  integrity sha512-jeGCyD0twyD2/lhb5OmhwKzGQXPAmCVIHBr6/BpUA6LvVOvzDwTBwUqWLZKgiNkfqm98HD40VmIwn1/FrFrL2Q==
+  dependencies:
+    "@angular-devkit/architect" "0.13.4"
+    "@angular-devkit/core" "7.3.4"
+    rxjs "6.3.3"
+    semver "5.6.0"
+
 "@angular-devkit/build-optimizer@0.13.3":
   version "0.13.3"
   resolved "https://registry.yarnpkg.com/@angular-devkit/build-optimizer/-/build-optimizer-0.13.3.tgz#30eb1bae6adfe48a28a0e244c8650ba2fec24fab"


### PR DESCRIPTION
Allows to rebuild components package only when a commit affects content of the package. CI builds will become faster.